### PR TITLE
Build vim with all features including clipboard support

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -47,6 +47,7 @@ class Vim < Formula
     system "./configure", "--prefix=#{HOMEBREW_PREFIX}",
                           "--mandir=#{man}",
                           "--enable-multibyte",
+                          "--with-features=huge",
                           "--with-tlib=ncurses",
                           "--with-compiledby=Homebrew",
                           "--enable-cscope",
@@ -54,8 +55,7 @@ class Vim < Formula
                           "--enable-perlinterp",
                           "--enable-rubyinterp",
                           "--enable-python3interp",
-                          "--enable-gui=no",
-                          "--without-x",
+                          "--enable-gui=gtk2",
                           "--enable-luainterp",
                           "--with-lua-prefix=#{Formula["lua"].opt_prefix}"
     system "make"


### PR DESCRIPTION
Build vim with the huge features type option that includes clipboard support and many other features that are popular and important to users.

The `--without-x` option has been deprecated and removed from vim's configure script thus the need to delete it here too.

The gui option has been added to utilize X11 GUI.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/linuxbrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/linuxbrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?
- [ ] Have you included the output of `brew gist-logs <formula>` of the build failure if your PR fixes a build failure. Please quote the exact error message.

-----
